### PR TITLE
Add D1

### DIFF
--- a/exercise_D/ExD.py
+++ b/exercise_D/ExD.py
@@ -1,0 +1,30 @@
+def generate_racing_horse_dict():
+    ret_dict = {
+        'Symboli Rudolf': {
+            'birthdate': '19830413',
+            'race_num': 16,
+            'win_num': 13,
+            'win_ratio': 13/16,
+            'Sire': 'Partholon',
+            'Dam': 'Sweet Luna'},
+        'Contrail': {
+            'birthdate': '20170401',
+            'race_num': 11,
+            'win_num': 8,
+            'win_ratio': 8/11,
+            'Sire': 'Deep Impact',
+            'Dam': 'Rhodochrosite'},
+        'Deep Impact': {
+            'birthdate': '20020325',
+            'race_num': 14,
+            'win_num': 12,
+            'win_ratio': 12/14,
+            'Sire': 'Sunday Silence',
+            'Dam': 'Wind in Her Hair'}
+        }
+    return ret_dict
+
+
+if __name__ == '__main__':
+    horses = generate_racing_horse_dict()
+    print(horses)


### PR DESCRIPTION
ExD.pyのコードに、D1の問題
=================
日本の競馬でG1で三冠以上の成績を上げた競走馬を調べ、そのうち任意に三頭を選んで、競走馬の英名をkeyとして生年月日、出走数、勝利数、勝率、父、母をvalueの辞書として持つ辞書を作成して返り値とする関数generate_racing_horse_dictを作成せよ。返り値のイメージとしては以下の形{'Symboli Rudolf': {'birthdate': '19830413', 'race_num': 16, 'win_num': 13, 'win_ratio': 13/16, 'Sire': 'Partholon', 'Dam': 'Sweet Luna'}, ...}
=================
の回答を記載しました。

次のステップは以下です。
=================
generate_racing_horse_dictにより生成された辞書race_horse_dictを入力し、出走数、勝利数、勝率が最も高い競走馬をそれぞれ抽出した辞書{'top_run': 'A', 'top_win': 'B', 'top_ratio': 'C'}を返り値として返すような関数get_topを作成せよ。
=================
ご確認お願いします。